### PR TITLE
Do not import numpy.int, which was deprecated and removed

### DIFF
--- a/opfunu/cec/cec2020/engineering.py
+++ b/opfunu/cec/cec2020/engineering.py
@@ -7,7 +7,7 @@
 #       Github:     https://github.com/thieu1995                                                  %
 # -------------------------------------------------------------------------------------------------------%
 
-from numpy import zeros, array, log, abs, exp, sqrt, pi, round, sin, cos, arccos, remainder, arcsin, int, arctan, imag, log10
+from numpy import zeros, array, log, abs, exp, sqrt, pi, round, sin, cos, arccos, remainder, arcsin, arctan, imag, log10
 from scipy.optimize import fminbound
 from opfunu.cec.cec2020 import constant
 


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

This has always just aliased Python’s built-in `int` type; it was [deprecated in 1.20.0](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) and [removed in 1.24.0](https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations).

We simply omit the import and use the built-in `int` type directly.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->


This fixes an error when running the tests with recent numpy versions:

```
==================================== ERRORS ====================================
__________________ ERROR collecting examples/test_cec2020.py ___________________
ImportError while importing test module '/builddir/build/BUILD/opfunu-1.0.0/examples/test_cec2020.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
examples/test_cec2020.py:8: in <module>
    from opfunu.cec.cec2020 import engineering
opfunu/cec/cec2020/engineering.py:9: in <module>
    from numpy import zeros, array, log, abs, exp, sqrt, pi, round, sin, cos, arccos, remainder, arcsin, int, arctan, imag, log10
E   ImportError: cannot import name 'int' from 'numpy' (/usr/lib/python3.11/site-packages/numpy/__init__.py)
```