### PR TITLE
fix: align `modified_schwefel_func()` in `operator.py`, close #21

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+# Version 1.0.2
+
++ Fix modified_schwefel_func() in operator.py
+
+---------------------------------------------------------------------
 
 # Version 1.0.1
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ---
 
 
-[![GitHub release](https://img.shields.io/badge/release-1.0.1-yellow.svg)](https://github.com/thieu1995/opfunu/releases)
+[![GitHub release](https://img.shields.io/badge/release-1.0.2-yellow.svg)](https://github.com/thieu1995/opfunu/releases)
 [![Wheel](https://img.shields.io/pypi/wheel/gensim.svg)](https://pypi.python.org/pypi/opfunu) 
 [![PyPI version](https://badge.fury.io/py/opfunu.svg)](https://badge.fury.io/py/opfunu)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/opfunu.svg)
@@ -40,7 +40,7 @@ traditional functions with different dimensions are implemented.
 
 Install the [current PyPI release](https://pypi.python.org/pypi/opfunu):
 ```sh
-$ pip install opfunu==1.0.1
+$ pip install opfunu==1.0.2
 ```
 
 Or install the development version from GitHub:

--- a/opfunu/utils/operator.py
+++ b/opfunu/utils/operator.py
@@ -280,10 +280,10 @@ def modified_schwefel_func(x):
     mask2 = z < -500
     mask3 = ~mask1 & ~mask2
     fx = np.zeros(nx)
-    fx[mask1] -= (500.0 + np.fmod(np.abs(z[mask1]), 500)) * np.sin(np.sqrt(500.0 - np.fmod(np.abs(z[mask1]), 500))) - (
-                (z[mask1] - 500.0) / 100.) ** 2 / nx
+    fx[mask1] -= ((500.0 - np.fmod(z[mask1], 500)) * np.sin(np.sqrt(500.0 - np.fmod(z[mask1], 500))) -
+                 ((z[mask1] - 500.0) / 100.) ** 2 / nx)
     fx[mask2] -= (-500.0 + np.fmod(np.abs(z[mask2]), 500)) * np.sin(np.sqrt(500.0 - np.fmod(np.abs(z[mask2]), 500))) - (
-                (z[mask2] + 500.0) / 100.) ** 2 / nx
+                 (z[mask2] + 500.0) / 100.) ** 2 / nx
     fx[mask3] -= z[mask3] * np.sin(np.sqrt(np.abs(z[mask3])))
 
     return np.sum(fx) + 4.189828872724338e+002 * nx


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #21

## 📑 Description
I've compared the function operations with the function in [CEC2021 C Code](https://github.com/P-N-Suganthan/2021-SO-BCO/blob/main/C-Code.zip) and updated the `modified_schwefel_func()` in `operator.py` to match with the function in `cec21_test_func.cpp` (line 1672 `void schwefel_func ()`). I have also used the same code mentioned in issue #21 to verify if the global minimum indeed equals the bias (1100.0). The result looks like this:
![Image](https://github.com/thieu1995/opfunu/assets/65713587/06f96eb8-e483-4db1-915f-c178fe8ab4b4)
which seems correct. I'm relatively new to this domain, so I welcome any feedback or suggestions to improve this fix. If there are any CI checks or additional testing required, please let me know, and I'll be happy to comply.

## ✅ Checks
- [v] My pull request adheres to the code style of this project
- [v] My code requires changes to the documentation
- [v] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
I have tested the changes locally, but I'm not entirely sure if all the CI checks have passed. If there are any specific tests or checks that need to be conducted, please advise, and I'll make the necessary adjustments.

The English writing of this request is helped by GPT-4.
Thanks [CharlesChiuGit](https://github.com/CharlesChiuGit) for helping me format my PR.